### PR TITLE
Refs: #9191 change dir name in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The online documentation generated with this project can be found in [eProsima p
     cd ~/all-docs
     python3 -m venv all-docs-venv
     source all-docs-venv/bin/activate
-    pip3 install -r docs/requirements.txt
+    pip3 install -r source/requirements.txt
     ```
 
 ## Getting Started


### PR DESCRIPTION
Signed-off-by: jparisu <javierparis@eprosima.com>

The name of the directory is **source**, and not **docs** (as it is in Fast-RTPS-docs).
So the instruction to find requirements.txt must use the dir **source**
`pip3 install -r source/requirements.txt `